### PR TITLE
Add compatibility with 3.0

### DIFF
--- a/octopress-autoprefixer.gemspec
+++ b/octopress-autoprefixer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'octopress-hooks', '~> 2.0'
   gem.add_runtime_dependency 'autoprefixer-rails', '~> 2.2'
-  gem.add_runtime_dependency 'jekyll', '=> 2.0'
+  gem.add_runtime_dependency 'jekyll', '>= 2.0'
 
   gem.add_development_dependency 'clash', '~> 1.0'
   gem.add_development_dependency 'pry-debugger'

--- a/octopress-autoprefixer.gemspec
+++ b/octopress-autoprefixer.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_runtime_dependency 'octopress-hooks', '~> 2.0'
-  gem.add_runtime_dependency "autoprefixer-rails", "~> 2.2"
-  gem.add_runtime_dependency 'jekyll', '~> 2.0'
+  gem.add_runtime_dependency 'autoprefixer-rails', '~> 2.2'
+  gem.add_runtime_dependency 'jekyll', '=> 2.0'
 
   gem.add_development_dependency 'clash', '~> 1.0'
   gem.add_development_dependency 'pry-debugger'


### PR DESCRIPTION
Autoprefixer appears to work with Jekyll 3 (pre-release), so can we afford to be a little more lenient with the spec?