### PR TITLE
Process CSS content before erasing file for writing

### DIFF
--- a/lib/octopress-autoprefixer.rb
+++ b/lib/octopress-autoprefixer.rb
@@ -22,8 +22,9 @@ module Octopress
 
     def self.prefix(stylesheet)
       content = File.open(stylesheet).read
+      prefixed_content = AutoprefixerRails.process(content)
       File.open(stylesheet, 'w') do |f|
-        f.write(AutoprefixerRails.process(content))
+        f.write(prefixed_content)
       end
     end
   end


### PR DESCRIPTION
Hi,

I am using this plugin for my Jekyll-based personal site, and it works well for the most part. However, I've noticed a "flash of unstyled content" on my site when I reload the page before my Jekyll build finishes (which happens quite often, since this plugin seems to lengthen my build time substantially, and it's more difficult for me to intuitively guess when my build is done).

Fortunately, I found the cause of the issue by examining your source code. Recall that opening a file in 'w' mode initially erases the file. In this case, the file was being prefixed *after* the file was opened, meaning that the file would be empty for as long as the `AutoprefixerRails.process` function would take to execute. This also implies that if the `AutoprefixerRails.process` function raises an exception, then the file will remain empty.

As you can see, I have submitted in this PR the simple fix (which involves processing the file before opening it for writing). Please consider merging this in and drafting new release.

Thanks,
Caleb